### PR TITLE
Add DataPile ETL prototype

### DIFF
--- a/DataPile ETL/README.md
+++ b/DataPile ETL/README.md
@@ -1,0 +1,25 @@
+# DataPile ETL
+
+This project provides a minimal prototype of the **DataPile ETL – Automotive Supplier Finder & Enrichment App**.
+
+It includes a simple FastAPI backend with a sample dataset and a small static HTML frontend.
+Due to the limited environment the backend returns data from a local CSV file instead of performing online queries.
+
+## Structure
+- `backend/` – FastAPI application with a `/search` endpoint.
+- `frontend/` – static HTML and JavaScript files to query the backend.
+- `requirements.txt` – Python dependencies for the backend.
+
+## Running the Backend
+Use Uvicorn to start the API:
+```bash
+cd backend
+python3 main.py
+```
+The API will listen on `http://127.0.0.1:8000`.
+
+## Running the Frontend
+Open `frontend/index.html` in a browser while the backend is running.
+
+## Export Data
+The frontend can download search results as a CSV file.

--- a/DataPile ETL/backend/main.py
+++ b/DataPile ETL/backend/main.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI, Query
+from fastapi.responses import JSONResponse
+import csv
+import os
+
+app = FastAPI(title="DataPile ETL")
+
+def load_data():
+    records = []
+    path = os.path.join(os.path.dirname(__file__), 'sample_data.csv')
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            records.append(row)
+    return records
+
+data = load_data()
+
+@app.get('/search')
+def search(component: str = Query(..., description="Component name")):
+    results = [r for r in data if r['Component'].lower() == component.lower()]
+    return JSONResponse({"results": results})
+
+if __name__ == '__main__':
+    import uvicorn
+    uvicorn.run(app, host='0.0.0.0', port=8000)

--- a/DataPile ETL/backend/sample_data.csv
+++ b/DataPile ETL/backend/sample_data.csv
@@ -1,0 +1,13 @@
+Component,Supplier Name,Major Supplier,Website URL,Country of Headquarters,Other Products,Capabilities or Technologies,Known OEM Customers,Certifications,Other Products2,# Production Sites,# R&D Centers,Production Countries,Ownership Type,Major Investors / Parent
+Aluminium Wheels,Ronal Group,Yes,https://www.ronalgroup.com,Switzerland,Alloy Wheels,Lightweight design,Audi;BMW;VW,ISO 9001,Accessories,8,2,Germany;Switzerland,Private,
+Aluminium Wheels,BBS,Yes,https://www.bbs.com,Germany,Performance Wheels,Flow forming,Ford;Toyota,ISO 14001,Racing Wheels,3,1,Germany,Public,BBS Japan
+Active Bar,thyssenkrupp,Yes,https://www.thyssenkrupp-automotive-technology.com,Germany,Suspension Components,Active roll stabilization,BMW;Mercedes-Benz,ISO/TS 16949,Springs,10,3,Germany;USA,Public,thyssenkrupp AG
+Active Bar,ZF,Yes,https://www.zf.com,Germany,Chassis Systems,Electromechanical systems,Audi;Ford,ISO 9001,Steering Systems,20,5,Global,Private,Zeppelin Foundation
+Brake Pads,Brembo,Yes,https://www.brembo.com,Italy,Brake Rotors,High performance friction,Ferrari;Porsche,ISO 14001,Calipers,15,4,Global,Public,
+Fuel Injectors,Bosch,Yes,https://www.bosch.com,Germany,Sensors,Precision injection,GM;VW,ISO 9001,Spark Plugs,50,6,Global,Private,Robert Bosch Stiftung
+Steering Wheel,Nardi,No,https://www.nardi-personal.com,Italy,Shift Knobs,Craftsmanship,Alfa Romeo,ISO 9001,Racing Accessories,1,0,Italy,Private,
+Turbocharger,Garrett Motion,Yes,https://www.garrettmotion.com,USA,Electric Boosting,Turbo technology,BMW;Ford,ISO/TS 16949,Intercoolers,12,2,USA;China,Public,
+Battery Pack,CATL,Yes,https://www.catl.com,China,Lithium Cells,Battery management,Tesla;BMW,ISO 9001,Energy Storage,9,3,China,Public,
+Radiator,Denso,Yes,https://www.denso.com,Japan,HVAC Systems,Thermal management,Toyota;Honda,ISO 14001,AC Compressors,40,5,Global,Public,
+Air Filter,Mahle,Yes,https://www.mahle.com,Germany,Oil Filters,Filtration technology,Mercedes;VW,ISO 9001,Cabin Filters,30,4,Global,Private,Mahle Stiftung
+Shock Absorber,Monroe,Yes,https://www.monroe.com,USA,Suspension Struts,Damping expertise,GM;Ford,ISO/TS 16949,Mounting Kits,22,3,USA;Europe,Public,Tenneco

--- a/DataPile ETL/frontend/index.html
+++ b/DataPile ETL/frontend/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>DataPile ETL</title>
+    <style>
+        table, th, td { border: 1px solid black; border-collapse: collapse; }
+        th, td { padding: 4px; }
+    </style>
+</head>
+<body>
+    <h1>DataPile ETL</h1>
+    <input type="text" id="component" placeholder="Component name" />
+    <button onclick="performSearch()">Search</button>
+    <button onclick="exportCSV()">Export CSV</button>
+    <div id="status"></div>
+    <table id="results"></table>
+<script src="script.js"></script>
+</body>
+</html>

--- a/DataPile ETL/frontend/script.js
+++ b/DataPile ETL/frontend/script.js
@@ -1,0 +1,48 @@
+async function performSearch() {
+    const comp = document.getElementById('component').value;
+    document.getElementById('status').innerText = 'Searching...';
+    const resp = await fetch(`http://localhost:8000/search?component=${encodeURIComponent(comp)}`);
+    const data = await resp.json();
+    renderTable(data.results);
+    window.currentResults = data.results;
+    document.getElementById('status').innerText = `Found ${data.results.length} result(s)`;
+}
+
+function renderTable(results) {
+    const tbl = document.getElementById('results');
+    tbl.innerHTML = '';
+    if (!results.length) return;
+    const headers = Object.keys(results[0]);
+    const thead = document.createElement('tr');
+    headers.forEach(h => {
+        const th = document.createElement('th');
+        th.textContent = h;
+        thead.appendChild(th);
+    });
+    tbl.appendChild(thead);
+    results.forEach(row => {
+        const tr = document.createElement('tr');
+        headers.forEach(h => {
+            const td = document.createElement('td');
+            td.textContent = row[h];
+            tr.appendChild(td);
+        });
+        tbl.appendChild(tr);
+    });
+}
+
+function exportCSV() {
+    if (!window.currentResults || !window.currentResults.length) return;
+    const headers = Object.keys(window.currentResults[0]);
+    let csv = headers.join(',') + '\n';
+    window.currentResults.forEach(row => {
+        csv += headers.map(h => JSON.stringify(row[h] || '')).join(',') + '\n';
+    });
+    const blob = new Blob([csv], {type: 'text/csv'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'results.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+}

--- a/DataPile ETL/output_results.csv
+++ b/DataPile ETL/output_results.csv
@@ -1,0 +1,13 @@
+Component,Supplier Name,Major Supplier,Website URL,Country of Headquarters,Other Products,Capabilities or Technologies,Known OEM Customers,Certifications,Other Products2,# Production Sites,# R&D Centers,Production Countries,Ownership Type,Major Investors / Parent
+Aluminium Wheels,Ronal Group,Yes,https://www.ronalgroup.com,Switzerland,Alloy Wheels,Lightweight design,Audi;BMW;VW,ISO 9001,Accessories,8,2,Germany;Switzerland,Private,
+Aluminium Wheels,BBS,Yes,https://www.bbs.com,Germany,Performance Wheels,Flow forming,Ford;Toyota,ISO 14001,Racing Wheels,3,1,Germany,Public,BBS Japan
+Active Bar,thyssenkrupp,Yes,https://www.thyssenkrupp-automotive-technology.com,Germany,Suspension Components,Active roll stabilization,BMW;Mercedes-Benz,ISO/TS 16949,Springs,10,3,Germany;USA,Public,thyssenkrupp AG
+Active Bar,ZF,Yes,https://www.zf.com,Germany,Chassis Systems,Electromechanical systems,Audi;Ford,ISO 9001,Steering Systems,20,5,Global,Private,Zeppelin Foundation
+Brake Pads,Brembo,Yes,https://www.brembo.com,Italy,Brake Rotors,High performance friction,Ferrari;Porsche,ISO 14001,Calipers,15,4,Global,Public,
+Fuel Injectors,Bosch,Yes,https://www.bosch.com,Germany,Sensors,Precision injection,GM;VW,ISO 9001,Spark Plugs,50,6,Global,Private,Robert Bosch Stiftung
+Steering Wheel,Nardi,No,https://www.nardi-personal.com,Italy,Shift Knobs,Craftsmanship,Alfa Romeo,ISO 9001,Racing Accessories,1,0,Italy,Private,
+Turbocharger,Garrett Motion,Yes,https://www.garrettmotion.com,USA,Electric Boosting,Turbo technology,BMW;Ford,ISO/TS 16949,Intercoolers,12,2,USA;China,Public,
+Battery Pack,CATL,Yes,https://www.catl.com,China,Lithium Cells,Battery management,Tesla;BMW,ISO 9001,Energy Storage,9,3,China,Public,
+Radiator,Denso,Yes,https://www.denso.com,Japan,HVAC Systems,Thermal management,Toyota;Honda,ISO 14001,AC Compressors,40,5,Global,Public,
+Air Filter,Mahle,Yes,https://www.mahle.com,Germany,Oil Filters,Filtration technology,Mercedes;VW,ISO 9001,Cabin Filters,30,4,Global,Private,Mahle Stiftung
+Shock Absorber,Monroe,Yes,https://www.monroe.com,USA,Suspension Struts,Damping expertise,GM;Ford,ISO/TS 16949,Mounting Kits,22,3,USA;Europe,Public,Tenneco

--- a/DataPile ETL/requirements.txt
+++ b/DataPile ETL/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add minimal DataPile ETL project with FastAPI backend and simple HTML frontend
- provide sample dataset and example output file
- fix data loading path in backend

## Testing
- `python3 DataPile\ ETL/backend/main.py &` *(fails: FileNotFoundError)*
- `python3 DataPile\ ETL/backend/main.py &` and `curl -s http://localhost:8000/search?component=Aluminium%20Wheels | head`

------
https://chatgpt.com/codex/tasks/task_e_68679a9566088324abbd59d3413b4af6